### PR TITLE
Initial work on new global profile page

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -112,6 +112,11 @@ class Post(models.Model):
         elif first_save:
             self.id = f"{API_BASE}/authors/{self.author._id}/posts/{self._id}"
             self.comments = f"{self.id}/comments"
+
+            # when creating a new post on our own server, we need to set the source and origin
+            # double check w/ TA if this is correct
+            self.source = f"{API_BASE}/authors/{self.author._id}/posts/{self._id}"
+            self.origin = f"{API_BASE}/authors/{self.author._id}/posts/{self._id}"
         return super().save(*args, **kwargs)
 
 class Comment(models.Model):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,14 +1,14 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from . import views
 from django.views.generic import TemplateView
 
 urlpatterns = [
     path('authors', views.Authors.as_view()),
-    path('authors/<author_id>', views.AuthorDetail.as_view()),
-    path('authors/<author_id>/followers', views.Followers.as_view()),
-    path('authors/<author_id>/followers/<foreign_author_id>', views.FollowersDetail.as_view()),
-    path('authors/<author_id>/posts', views.Posts.as_view()),
+    path('authors/<path:author_id>/followers/<path:foreign_author_id>', views.FollowersDetail.as_view()),
+    path('authors/<path:author_id>/followers', views.Followers.as_view()),
+    path('authors/<path:author_id>/posts', views.Posts.as_view()),
+    path('authors/<path:author_id>', views.AuthorDetail.as_view()),
     path('authors/<author_id>/posts/<post_id>', views.PostDetail.as_view()),
     path('authors/<author_id>/posts/<post_id>/image', views.ImagePosts.as_view()),
     path('authors/<author_id>/posts/<post_id>/comments', views.Comments.as_view()),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -12,6 +12,7 @@ from rest_framework.pagination import PageNumberPagination
 from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse, OpenApiTypes
 from pprint import pprint
 import docs.docs as docs
+import urllib.parse
 
 from .serializers import AuthorSerializer, PostSerializer, CommentSerializer, LikeSerializer, FollowSerializer, UserSerializer, InboxSerializer, InboxPostSerializer
 from .models import Author, Post, Comment, Like, Inbox, Follow
@@ -70,9 +71,12 @@ class AuthorDetail(APIView):
         """
         Get details for an author
         """
+
+        print("in AuthorDetail")
         
         # Extract a uuid if id was given in the form http://somehost/authors/<uuid>
         author_id = extract_uuid_if_url('author', author_id)
+
         if not author_id:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import Profile from './pages/Profile';
 import SearchResults from './pages/SearchResults';
 import Auth from './pages/Auth';
 import Explore from './pages/Explore';
+import GlobalProfile from './pages/GlobalProfile';
 
 const router = createBrowserRouter([
   // need to change to splash screen/login
@@ -49,6 +50,11 @@ const router = createBrowserRouter([
   {
     path: "/profile",
     element: <Profile/>,
+    key: Math.random(),
+  },
+  {
+    path:"/profile/:authorURL",
+    element: <GlobalProfile/>,
     key: Math.random(),
   },
   {

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -176,7 +176,7 @@ const Post = ({
                     {/* Post details */}
                     <Grid item xs={12}>
                         <div style={{ display: "flex", justifyContent: "space-between" }}>
-                            <div style={{ display: "flex", alignItems: "center" }}>
+                            <div style={{ display: "flex", alignItems: "left" }}>
                                 <AccountCircleIcon sx={{ fontSize: "40px", color: "#F5F5F5", marginRight: "10px" }} />
 
                                 <div>
@@ -280,8 +280,22 @@ const Post = ({
                         </div>
                     </Grid>
 
+
+
                     {!hideLink &&
                         <>
+                            <Grid item xs={12}>
+                                <TextField fullWidth label="Source" value={source}></TextField>
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <TextField fullWidth label="Origin" value={origin}></TextField>
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Divider />
+                            </Grid>
+
                             <Grid item xs={12}>
                                 <TextField fullWidth label="Post URI" value={link}></TextField>
                             </Grid>

--- a/frontend/src/pages/GlobalProfile.js
+++ b/frontend/src/pages/GlobalProfile.js
@@ -1,0 +1,260 @@
+// React helpers
+import { useParams } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { createAPIEndpoint } from '../api';
+
+// Layout components
+import Layout from "../components/layouts/Layout";
+import Post from "../components/Post";
+
+// Material UI elements
+import { Grid, Card, Typography, CircularProgress, Chip, Divider, Dialog, DialogContent, DialogTitle } from "@mui/material";
+
+// Material UI icons
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import FaceIcon from '@mui/icons-material/Face';
+import PagesIcon from '@mui/icons-material/Pages';
+import ErrorIcon from '@mui/icons-material/Error';
+
+const GlobalProfile = () => {
+
+    const navigate = useNavigate();
+
+    const { authorURL } = useParams()
+    // decode authorURL from URL encoded
+    const authorURLDecoded = decodeURIComponent(authorURL)
+
+    const [loading, setLoading] = useState(true);
+
+    const [showFollowers, setShowFollowers] = useState(false);
+    const [followersLoading, setFollowersLoading] = useState(true);
+
+    const [error, setError] = useState(false);
+    const [errorMessage, setErrorMessage] = useState(null);
+
+    const [authorDetails, setAuthorDetails] = useState(null);
+    const [authorPosts, setAuthorPosts] = useState(null);
+    const [authorServer, setAuthorServer] = useState(null);
+    const [authorFollowerDetails, setAuthorFollowerDetails] = useState(null);
+
+    useEffect(() => {
+
+        // first, set loading to true
+        setLoading(true)
+
+        // if authorURLDecoded is undefinfed, show error message
+        if (authorURLDecoded === undefined) {
+            setError(true)
+            setErrorMessage("User not found.")
+            setLoading(false)
+        }
+
+        // otherwise, if authorURLDecoded starts with https://social-distribution-media.herokuapp.com, use createAPIEndpoint to get author details + recent posts
+        else if (authorURLDecoded.startsWith("https://social-distribution-media.herokuapp.com")) {
+            createAPIEndpoint(`authors/${authorURLDecoded}`)
+                .get()
+                .then(res => {
+                    setAuthorDetails(res.data)
+                    setAuthorServer("Local")
+
+                    createAPIEndpoint(`authors/${authorURLDecoded}/posts`)
+                        .get()
+                        .then(res => {
+                            setAuthorPosts(res.data)
+                            setLoading(false)
+                        })
+                        .catch(err => {
+                            // TODO: Add in error handling
+                            console.log(err)
+                            setError(true)
+                            setErrorMessage("An unexpected error occurred loading profile content.")
+                            setLoading(false)
+                        });
+                })
+                .catch(err => {
+                    // TODO: Add in error handling
+                    console.log(err)
+                    setError(true)
+                    setErrorMessage("An unexpected error occurred loading profile content.")
+                    setLoading(false)
+                });
+
+        }
+
+        // otherwise, if authorURLDecoded does not start with https://social-distribution-media.herokuapp.com, make request some other way
+        else if (!authorURLDecoded.startsWith("https://social-distribution-media.herokuapp.com")) {
+            // TODO: get remote author details
+            setLoading(false)
+        }
+
+        // otherwise, show error message
+        else {
+            setError(true)
+            setErrorMessage("User not found.")
+            setLoading(false)
+        }
+    }, [])
+
+    async function loadFollowers() {
+        setShowFollowers(true)
+
+        if (authorURLDecoded.startsWith("https://social-distribution-media.herokuapp.com")) {
+            // TODO: get local author followers
+            var allLocalFollowers = []
+            for (let follower of authorDetails.followers) {
+                const response = await createAPIEndpoint(`authors/${follower}`).get()
+                allLocalFollowers.push(response.data)
+            }
+
+            setAuthorFollowerDetails(allLocalFollowers)
+            setFollowersLoading(false)
+        }
+
+        else if (!authorURLDecoded.startsWith("https://social-distribution-media.herokuapp.com")) {
+            // TODO: get remote author followers
+        }
+    }
+
+    return (
+        <>
+            <Layout>
+                <Dialog open={showFollowers} style={{ padding: "20px" }}>
+                    <DialogTitle>Followers</DialogTitle>
+
+                    <DialogContent>
+                        <Grid container spacing={2}>
+                            {followersLoading &&
+                                <Grid item xs={12}>
+                                    <CircularProgress sx={{ margin: "20px" }} />
+                                </Grid>
+                            }
+
+                            {!followersLoading &&
+                                <>
+                                    {authorFollowerDetails.map((follower, index) => (
+                                        <Grid item xs={12}>
+                                            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                                                <Typography sx={{marginRight: "100px"}}>{follower.displayName}</Typography>
+
+                                                <Chip label="View" clickable onClick={() => {navigate(`/profile/${encodeURIComponent(follower.url)}`, {replace: true}); window.location.reload();}}/>
+                                            </div>
+                                        </Grid>
+                                    ))}
+                                </>
+                            }
+                        </Grid>
+                    </DialogContent>
+                </Dialog>
+
+                <Grid container spacing={2}>
+                    {loading &&
+                        <Grid item xs={12}>
+                            <Card>
+                                <CircularProgress />
+                            </Card>
+                        </Grid>
+                    }
+
+                    {!loading && error &&
+                        <Grid item xs={12}>
+                            <Card>
+                                <ErrorIcon sx={{ fontSize: "60px" }} />
+                                <Typography variant="h6" component="h2" sx={{ textAlign: "center" }}>{errorMessage}</Typography>
+                            </Card>
+                        </Grid>
+                    }
+
+                    {!loading && !error &&
+                        <>
+                            <Grid item xs={12}>
+                                <Card>
+                                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                                        <div style={{ display: "flex", alignItems: "center" }}>
+                                            <AccountCircleIcon sx={{ fontSize: "40px", color: "#F5F5F5", marginRight: "10px" }} />
+                                            <Typography variant="h6" align="left">@{authorDetails.displayName}</Typography>
+                                        </div>
+
+                                        <Chip label={authorServer} />
+                                    </div>
+                                </Card>
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Divider />
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Typography variant="h6" align="left">Followers</Typography>
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Card>
+                                    {authorDetails.followers.length === 0 &&
+                                        <Typography variant="body1" align="left">No followers.</Typography>
+                                    }
+
+                                    {authorDetails.followers.length > 0 &&
+                                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                                            <Typography variant="h6" align="left">{authorDetails.followers.length}</Typography>
+
+                                            <Chip label="View All" clickable onClick={() => { loadFollowers() }} />
+                                        </div>
+                                    }
+                                </Card>
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Divider />
+                            </Grid>
+
+                            <Grid item xs={12}>
+                                <Typography variant="h6" align="left">Posts</Typography>
+                            </Grid>
+
+                            {authorPosts.length === 0 &&
+                                <Grid item xs={12}>
+                                    <Card>
+                                        <Typography variant="body1" align="left">No posts to show.</Typography>
+                                    </Card>
+                                </Grid>
+                            }
+
+                            {authorPosts.map((post, index) => (
+                                <Grid item xs={12} key={index}>
+                                    <Post
+                                        id={post["_id"]}
+                                        title={post.title}
+                                        description={post.description}
+                                        source={post.source}
+                                        origin={post.origin}
+                                        categories={post.categories}
+                                        type={post.contentType}
+                                        content={post.content}
+                                        authorDisplayName={authorDetails.displayName}
+                                        authorID={authorDetails.id}
+                                        link={post.id}
+
+                                        // Hide edit button + extra information
+                                        hideEditButton={true}
+                                        hideSource={true}
+                                        hideOrigin={true}
+                                        hideCategories={true}
+                                        hideLikeButton={true}
+                                        hideCommentButton={true}
+                                        hideShareButton={true}
+                                        hideDeleteButton={true}
+                                        hideLink={true}
+                                    />
+                                </Grid>
+                            ))}
+                        </>
+                    }
+
+                </Grid>
+            </Layout>
+        </>
+    )
+}
+
+export default GlobalProfile;

--- a/frontend/src/pages/NewPost.js
+++ b/frontend/src/pages/NewPost.js
@@ -76,8 +76,8 @@ const NewPost = () => {
                 var data = {
                     title: postTitle,
                     description: postDescription,
-                    source: "https://google.com",
-                    origin: "https://google.com",
+                    //source: "https://google.com",
+                    //origin: "https://google.com",
                     contentType: "text/markdown",
                     content: postContent,
                     categories: postCategories.replace(/\s/g, '').split(','),
@@ -85,7 +85,7 @@ const NewPost = () => {
                     unlisted: unlisted
                 }
 
-                console.log(data)
+                //console.log(data)
 
                 createAPIEndpoint(`authors/${userID}/posts`)
                     .post(data)
@@ -105,8 +105,8 @@ const NewPost = () => {
                 var data = {
                     title: postTitle,
                     description: postDescription,
-                    source: "https://google.com",
-                    origin: "https://google.com",
+                    //source: "https://google.com",
+                    //origin: "https://google.com",
                     contentType: "text/plain",
                     content: postContent,
                     categories: postCategories.replace(/\s/g, '').split(','),


### PR DESCRIPTION
Same update I left in Discord:

In screenshot #1 I redesigned the profile page so that it can show not just your own profile but other users' as well. So here notice how I'm logged in as "eric" but can see "john.doe"'s profile ! And it also displays a badge that tells you where the Profile stems from, so in this case "john.doe" is on our local server.

In screenshot #2 there's a new little "Followers" modal. Prob will redesign later to look nicer but does the trick because it has a "view" button for followers, which you can click, and then it takes you to another Profile page. 

The way this page works is it's a dynamic URL, so for example, `http://127.0.0.1:3000/profile/https%3A%2F%2Fsocial-distribution-media.herokuapp.com%2Fauthors%2F03b4614b-d4a2-46c7-8b5a-bf1dffc373cd`, so in screenshot #3 there's the differentiating logic to either make the request to our server or a remote one. In the remote if clause I'll likely just need to make a req to our backend to get the basic auth creds first to make the outbound request to the remote server,  but then ya other than that all the boilerplate is there to render the author info and posts and with that we're pretty much connected! So tomorrow I'll look at what groups we have creds for and start rigging it up !

![image](https://user-images.githubusercontent.com/15025400/226265281-6dbabe5b-6616-43ef-8b72-970e9839b3dc.png)
![image](https://user-images.githubusercontent.com/15025400/226265302-a3c619d5-a3d4-4484-9602-8d1373762892.png)
![image](https://user-images.githubusercontent.com/15025400/226265329-79c8711f-4fb6-48ac-aa1e-4983d0199e6d.png)

Also an example when a profile does have a post to show:
![image](https://user-images.githubusercontent.com/15025400/226265381-432ebc3d-9d73-4316-8f4d-0605acf99e79.png)

